### PR TITLE
Node connection awareness

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": false
-}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **IMPORTANT!** Make sure to:
 
-1.  Use [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and have the `Editor: Format On Save` setting in VSCode turned on to keep the code consistent.
+1.  Have the `Editor: Format On Save` setting in VSCode turned on to keep the code consistent.
 2.  Always run pre-commit checks before commiting your code. If it won't pass, it won't be able to be built. More info about the checks can be found below.
 3.  Check the other `README.md` files located in subfolders (if provided) for further info.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,21 +1,29 @@
 import React, { useEffect } from 'react'
 import { Router, Switch, Route, Redirect } from 'react-router-dom'
 import { createBrowserHistory } from 'history'
-import { useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
+import { useQuery } from '@apollo/react-hooks'
 
 import { NavigationProvider } from 'contexts'
 import { DefaultLayout } from 'layouts'
 import { SelectApi, Staking, Contact } from 'pages'
-import { apiSelector } from 'selectors'
+import { setApiAction } from 'actions'
+import { GetNodeInfo } from 'apollo/queries'
 
 const history = createBrowserHistory()
 
 const App = () => {
-  const api = useSelector(apiSelector)
+  const dispatch = useDispatch()
+
+  const { data } = useQuery(GetNodeInfo)
 
   useEffect(() => {
-    if (!api.loaded) history.push('/')
-  }, [api])
+    if (data?.nodeInfo) {
+      data.nodeInfo.chain
+        ? dispatch(setApiAction({ loaded: true }))
+        : history.push('/')
+    }
+  }, [data])
 
   return (
     <Router history={history}>

--- a/packages/client/src/apollo/queries/GetNodeInfo.ts
+++ b/packages/client/src/apollo/queries/GetNodeInfo.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export default gql`
+  query GetNodeInfo {
+    nodeInfo {
+      chain
+    }
+  }
+`

--- a/packages/client/src/apollo/queries/index.ts
+++ b/packages/client/src/apollo/queries/index.ts
@@ -1,2 +1,3 @@
 export { default as GetHeaders } from './GetHeaders'
 export { default as GetValidators } from './GetValidators'
+export { default as GetNodeInfo } from './GetNodeInfo'

--- a/packages/client/src/pages/SelectApi/SelectApi.tsx
+++ b/packages/client/src/pages/SelectApi/SelectApi.tsx
@@ -46,7 +46,7 @@ const SelectApi = () => {
           navigateTo('/staking')
         })
         .catch(() => {
-          if (snackbarRef && snackbarRef.current) snackbarRef.current.open()
+          if (snackbarRef?.current) snackbarRef.current.open()
           hideLoading()
         })
     }

--- a/packages/client/src/pages/Staking/Staking.tsx
+++ b/packages/client/src/pages/Staking/Staking.tsx
@@ -1,25 +1,25 @@
-import React from 'react'
-import { useQuery } from '@apollo/react-hooks'
-import { useSelector } from 'react-redux'
+import React from "react";
+import { useQuery } from "@apollo/react-hooks";
+import { useSelector } from "react-redux";
 
 // import { UiOptionType } from 'types'
-import { ValidatorInterface } from 'types'
+import { ValidatorInterface } from "types";
 // import { Loading, Select } from 'ui'
-import { Loading } from 'ui'
-import { ValidatorCard } from 'components'
-import { GetValidators } from 'apollo/queries'
-import { apiSelector } from 'selectors'
-import stakingDemo from 'mocks/staking'
+import { Loading } from "ui";
+import { ValidatorCard } from "components";
+import { GetValidators } from "apollo/queries";
+import { apiSelector } from "selectors";
+import stakingDemo from "mocks/staking";
 
-import * as S from './styled'
+import * as S from "./styled";
 
 type Data = {
-  validators: ValidatorInterface[]
-}
+  validators: ValidatorInterface[];
+};
 
 type QueryResult = {
-  data: Data
-}
+  data: Data;
+};
 
 const Staking = () => {
   // const filterOptions = [
@@ -33,13 +33,13 @@ const Staking = () => {
 
   // const [filter, setFilter] = useState<UiOptionType>(filterOptions[0])
 
-  const api = useSelector(apiSelector)
+  const api = useSelector(apiSelector);
 
   const query = useQuery(GetValidators, {
     pollInterval: 10000
-  })
+  });
 
-  const { data } = api.demo ? (stakingDemo as QueryResult) : query
+  const { data } = api.demo ? (stakingDemo as QueryResult) : query;
 
   return (
     <S.Wrapper>
@@ -54,43 +54,54 @@ const Staking = () => {
             />
           </S.Header> */}
           <S.Content>
-            {data.validators.map((item, idx) => (
-              <ValidatorCard
-                key={`validatorCard-${idx}`}
-                stashId={item.accountId}
-                controllerId={item.commissionData[0]?.controllerId}
-                sessionId={item.commissionData[0]?.sessionId}
-                bondedTotal={
-                  item.commissionData[0]?.nominatorData
-                    ? JSON.parse(item.commissionData[0].nominatorData)
-                        .totalStake
-                    : '0.000'
-                }
-                bondedSelf={item.commissionData[0]?.bondedSelf || '0.000'}
-                bondedFromNominators={
-                  item.commissionData[0]?.nominatorData
-                    ? JSON.parse(item.commissionData[0].nominatorData)
-                        .nominatorStake
-                    : '0.000'
-                }
-                commission={item.commissionData[0]?.commission}
-                blocksProduced={item.blocksProduced}
-                slashes={item.slashes}
-                recentlyOnline={item.recentlyOnline}
-                nominators={
-                  item.commissionData[0]?.nominatorData
-                    ? JSON.parse(item.commissionData[0].nominatorData).stakers
-                    : []
-                }
-              />
-            ))}
+            {data.validators.map((item, idx) => {
+              // TEMP SOLUTION, THE DATA STRUCTURE WILL CHANGE
+              const itemFormatted = {
+                ...item,
+                commissionData: item.commissionData?.length
+                  ? item.commissionData.map(data => ({
+                    ...data,
+                    nominatorData: data.nominatorData
+                      ? JSON.parse(data.nominatorData)
+                      : {}
+                  }))
+                  : [{}]
+              };
+
+              return (
+                <ValidatorCard
+                  key={`validatorCard-${idx}`}
+                  stashId={itemFormatted.accountId}
+                  controllerId={itemFormatted.commissionData[0].controllerId}
+                  sessionId={itemFormatted.commissionData[0].sessionId}
+                  bondedTotal={
+                    itemFormatted.commissionData[0].nominatorData?.totalStake ||
+                    "0.000"
+                  }
+                  bondedSelf={
+                    itemFormatted.commissionData[0].bondedSelf || "0.000"
+                  }
+                  bondedFromNominators={
+                    itemFormatted.commissionData[0].nominatorData
+                      ?.nominatorStake || "0.000"
+                  }
+                  commission={itemFormatted.commissionData[0].commission}
+                  blocksProduced={itemFormatted.blocksProduced}
+                  slashes={itemFormatted.slashes}
+                  recentlyOnline={itemFormatted.recentlyOnline}
+                  nominators={
+                    itemFormatted.commissionData[0].nominatorData?.stakers
+                  }
+                />
+              );
+            })}
           </S.Content>
         </>
       ) : (
         <Loading />
       )}
     </S.Wrapper>
-  )
-}
+  );
+};
 
-export default Staking
+export default Staking;

--- a/packages/client/src/pages/Staking/Staking.tsx
+++ b/packages/client/src/pages/Staking/Staking.tsx
@@ -39,7 +39,7 @@ const Staking = () => {
     pollInterval: 10000
   })
 
-  const { data } = api.demo ? stakingDemo as QueryResult : query
+  const { data } = api.demo ? (stakingDemo as QueryResult) : query
 
   return (
     <S.Wrapper>
@@ -60,16 +60,28 @@ const Staking = () => {
                 stashId={item.accountId}
                 controllerId={item.commissionData[0]?.controllerId}
                 sessionId={item.commissionData[0]?.sessionId}
-                bondedTotal={JSON.parse(item.commissionData[0]?.nominatorData)?.totalStake || '0.000'}
-                bondedSelf={item.commissionData[0]?.bondedSelf || '0.000'}
-                bondedFromNominators={JSON.parse(item.commissionData[0]?.nominatorData)?.nominatorStake || '0.000'}
-                commission={item.commissionData[0]?.commission}
-                blocksProduced={
-                  item.blocksProduced
+                bondedTotal={
+                  item.commissionData[0]?.nominatorData
+                    ? JSON.parse(item.commissionData[0].nominatorData)
+                        .totalStake
+                    : '0.000'
                 }
+                bondedSelf={item.commissionData[0]?.bondedSelf || '0.000'}
+                bondedFromNominators={
+                  item.commissionData[0]?.nominatorData
+                    ? JSON.parse(item.commissionData[0].nominatorData)
+                        .nominatorStake
+                    : '0.000'
+                }
+                commission={item.commissionData[0]?.commission}
+                blocksProduced={item.blocksProduced}
                 slashes={item.slashes}
                 recentlyOnline={item.recentlyOnline}
-                nominators={JSON.parse(item.commissionData[0]?.nominatorData)?.stakers}
+                nominators={
+                  item.commissionData[0]?.nominatorData
+                    ? JSON.parse(item.commissionData[0].nominatorData).stakers
+                    : []
+                }
               />
             ))}
           </S.Content>

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -10106,9 +10106,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.7.0-beta:
-  version "3.7.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-beta.tgz#4ad556e0eee14b90ecc39261001690e16e5eeba9"
-  integrity sha512-4jyCX+IQamrPJxgkABPq9xf+hUN+GWHVxoj+oey1TadCPa4snQl1RKwUba+1dyzYCamwlCxKvZQ3TjyWLhMGBA==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
- Fixed the bug which was crashing the app when nominatorData were undefined for some validator in the Staking page.
- Upgraded TS version and removed all traces of Prettier, since the default VSCode TS formatter now does a better job because it supports optional chaining
- The Client is now aware if the Server is connected to any node and if so, then the Client won't force the SelectApi screen upon initial load of the app